### PR TITLE
Fix download URL

### DIFF
--- a/wsk.rb
+++ b/wsk.rb
@@ -1,13 +1,13 @@
 class Wsk < Formula
   desc "openwhisk command-line utility"
   homepage "https://github.com/openwhisk/openwhisk"
-  url "https://openwhisk.ng.bluemix.net/cli/go/download/mac/amd64/openwhisk-mac-amd64.tar.gz"
-  sha256 "9d8863d28ead820678ebe82cd7370312e324518d56dd6f2cffcba4d9e991a21b"
+  url "https://openwhisk.eu-gb.bluemix.net/cli/go/download/mac/amd64/wsk"
+  sha256 "c78277d51dffda77e99507c630796519130f2122c27da4db164a6d191bb6100c"
+  version "08-Aug-2017_06:47" # from https://openwhisk.eu-gb.bluemix.net/cli/go/download/mac/amd64/
 
   bottle :unneeded
 
   def install
-    system "cp mac/amd64/wsk wsk"
     bin.install "wsk"
   end
 


### PR DESCRIPTION
* The previous URL does not work anymore
* For simplicity, download just the `wsk` binary instead of the ZIP file
* Emulate a version using the server timestamp until something like `wsk --version` is implemented